### PR TITLE
Joehoski/add link to introduction tutorial

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -275,6 +275,7 @@ $(document).ready(function () {
 <a class="list-group-item" href="boosting-2">Boosting 2</a>
 <a class="list-group-item" href="ensemble">Ensemble</a>
 <a class="list-group-item" href="interpretable-ml">Interpretable-ml</a>
+<a class="list-group-item" href="introduction">Introduction</a>
 <a class="list-group-item" href="knn">knn</a>
 <a class="list-group-item" href="ml-basics">Machine Learning Basics</a>
 <a class="list-group-item" href="ml-toolbox">Machine Learning Toolbox</a>

--- a/index.Rmd
+++ b/index.Rmd
@@ -30,6 +30,11 @@ library(htmltools)
           ),
           a(
             class="list-group-item",
+            "Introduction",
+            href="introduction"
+          ),
+          a(
+            class="list-group-item",
             "knn",
             href="knn"
           ),


### PR DESCRIPTION
The introduction tutorial in this collection of tutorials has no link to it from the landing page. This adds a link to the introduction tutorial. See screenshot below, the circled link is added by this code change.

![Screenshot 2023-07-12 at 12 57 49 PM](https://github.com/joevus/mlforsocialscience/assets/13547828/40924d0e-e367-4c92-8f66-85adbaa7cd82)
